### PR TITLE
restore last api spec on next visit

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -50,6 +50,9 @@ window.OAX.app = new Vue({
         .filter(v => v[0] === 'url')[0]
       url = qoq ? decodeURIComponent(qoq[1]) : url
     }
+    if (!url) {
+      url = localStorage.getItem('DGAE_RECENT_API')
+    }
 
     store.dispatch(types.SPEC_SET_LOAD_URL, url || configuration.url)
     this.online()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -102,7 +102,8 @@
       ])
     },
     created () {
-      this.SPEC_SET_LOAD_URL(this.$route.query.url || configuration.url)
+      const url = localStorage.getItem('DGAE_RECENT_API')
+      this.SPEC_SET_LOAD_URL(this.$route.query.url || url || configuration.url)
     },
     watch: {
       $route: function (value) {

--- a/store/modules/recent/index.js
+++ b/store/modules/recent/index.js
@@ -8,9 +8,8 @@ export const mutations = {
   [types.RECENT_SET_UNSHIFT] (state, payload) {
     const past = state.recent.filter(item => item.url === payload.url)
 
-    // if (past[0]) {
-    //   state.recent.splice(state.recent.indexOf(past[0]), 1)
-    // }
+    // store most recent url in localstorage to load at next visit
+    localStorage.setItem('DGAE_RECENT_API', payload.url)
 
     if (!past[0]) {
       state.recent.unshift(payload)


### PR DESCRIPTION
This commit contains changes to store the most recent api spec url in localStorage and to restore this api spec on the next visit.